### PR TITLE
Add support for the ml2 plugin

### DIFF
--- a/akanda/neutron/plugins/ml2_neutron_plugin.py
+++ b/akanda/neutron/plugins/ml2_neutron_plugin.py
@@ -31,7 +31,13 @@ class Ml2Plugin(floatingip.ExplicitFloatingIPAllocationMixin,
         ["dhrouterstatus"]
     )
 
-    @akanda.auto_add_other_resources
+    # The auto_add_other_resources decorator enable the automatic
+    # creation of a bunch of resources. These resources are in the
+    # form of neutron extensions and need to be registered with the
+    # plugin. Since we are not enabling those extension right now,
+    # lets comment out the decorator
+
+    # @akanda.auto_add_other_resources
     @akanda.auto_add_ipv6_subnet
     def create_network(self, context, network):
         return super(Ml2Plugin, self).create_network(context, network)

--- a/akanda/neutron/plugins/ml2_neutron_plugin.py
+++ b/akanda/neutron/plugins/ml2_neutron_plugin.py
@@ -1,0 +1,70 @@
+# Copyright 2014 DreamHost, LLC
+#
+# Author: DreamHost, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from neutron.plugins.ml2 import plugin
+from neutron.services.l3_router import l3_router_plugin
+
+from akanda.neutron.plugins import decorators as akanda
+from akanda.neutron.plugins import floatingip
+
+akanda.monkey_patch_ipv6_generator()
+
+
+class Ml2Plugin(floatingip.ExplicitFloatingIPAllocationMixin,
+                plugin.Ml2Plugin):
+
+    _supported_extension_aliases = (
+        plugin.Ml2Plugin._supported_extension_aliases +
+        ["dhrouterstatus"]
+    )
+
+    @akanda.auto_add_other_resources
+    @akanda.auto_add_ipv6_subnet
+    def create_network(self, context, network):
+        return super(Ml2Plugin, self).create_network(context, network)
+
+    @akanda.auto_add_subnet_to_router
+    def create_subnet(self, context, subnet):
+        return super(Ml2Plugin, self).create_subnet(context, subnet)
+
+    @akanda.sync_subnet_gateway_port
+    def update_subnet(self, context, id, subnet):
+        return super(Ml2Plugin, self).update_subnet(
+            context, id, subnet)
+
+
+class L3RouterPlugin(l3_router_plugin.L3RouterPlugin):
+
+    def list_routers_on_l3_agent(self, context, agent_id):
+        return {
+            'routers': self.get_routers(context),
+        }
+
+    def list_active_sync_routers_on_active_l3_agent(
+            self, context, host, router_ids):
+        # Override L3AgentSchedulerDbMixin method
+        filters = {}
+        if router_ids:
+            filters['id'] = router_ids
+        routers = self.get_routers(context, filters=filters)
+        new_router_ids = [r['id'] for r in routers]
+        if new_router_ids:
+            return self.get_sync_data(
+                context,
+                router_ids=new_router_ids,
+                active=True,
+            )
+        return []


### PR DESCRIPTION
Now that the ovs monolithic plugin has been deprecated we need
to switch to the ml2 plugin selecting ovs as mechanism driver.
All the methods we were overriding in the ovs plugin regarding
both L2 and L3 layers need now to be overriden in the two new
Ml2Plugin and L3RouterPlugin classes.

Change-Id: I08f904f2dc1f86139c44b8b208e57e5dd4ab552c
Signed-off-by: Rosario Di Somma <rosario.disomma@dreamhost.com>