### PR TITLE
Update _update_internal_gateway_port_ip to use the ml2 plugin

### DIFF
--- a/akanda/neutron/plugins/decorators.py
+++ b/akanda/neutron/plugins/decorators.py
@@ -236,6 +236,8 @@ def _update_internal_gateway_port_ip(context, router_id, subnet):
     ]
 
     plugin = manager.NeutronManager.get_plugin()
+    service_plugin = manager.NeutronManager.get_service_plugins().get(
+        constants.L3_ROUTER_NAT)
 
     for index, ip in enumerate(fixed_ips):
         if ip['subnet_id'] == subnet['id']:
@@ -248,7 +250,7 @@ def _update_internal_gateway_port_ip(context, router_id, subnet):
             break
     else:
         try:
-            plugin._check_for_dup_router_subnet(
+            service_plugin._check_for_dup_router_subnet(
                 context,
                 routerport.router,
                 subnet['network_id'],


### PR DESCRIPTION
The method, originally written for the ovs plugin, tries to use
the ovs driver for both L2 and L3 operation. Since we switched
to the ml2 plugin, which only manages L2 operations, we need
to call the L3 manager to make operations on routers.

Change-Id: Ic74bdd3d4dce09fdec0ad32775771fc0c564b6c2
Signed-off-by: Rosario Di Somma <rosario.disomma@dreamhost.com>