### PR TITLE
Workaround the broken inheritance heriarchy of the L3RouterPlugin

### DIFF
--- a/akanda/neutron/plugins/ml2_neutron_plugin.py
+++ b/akanda/neutron/plugins/ml2_neutron_plugin.py
@@ -14,6 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from neutron.db import l3_db
 from neutron.plugins.ml2 import plugin
 from neutron.services.l3_router import l3_router_plugin
 
@@ -53,6 +54,13 @@ class Ml2Plugin(floatingip.ExplicitFloatingIPAllocationMixin,
 
 
 class L3RouterPlugin(l3_router_plugin.L3RouterPlugin):
+
+    # An issue in neutron is making this class inheriting some
+    # methods from l3_dvr_db.L3_NAT_with_dvr_db_mixin.As a workaround
+    # we force it to use the original methods in the
+    # l3_db.L3_NAT_db_mixin class.
+    get_sync_data = l3_db.L3_NAT_db_mixin.get_sync_data
+    add_router_interface = l3_db.L3_NAT_db_mixin.add_router_interface
 
     def list_routers_on_l3_agent(self, context, agent_id):
         return {


### PR DESCRIPTION
An issue in neutron is making this class inheriting some
methods from l3_dvr_db.L3_NAT_with_dvr_db_mixin. As a workaround
we force it to use the original methods in the l3_db.L3_NAT_db_mixin
class.

Change-Id: I4310a7fde14a83887cfd6e503d08e4bbca3001ce
Signed-off-by: Rosario Di Somma <rosario.disomma@dreamhost.com>