### PR TITLE
Make the auto_add_subnet_to_router decorator work again

### DIFF
--- a/akanda/neutron/plugins/decorators.py
+++ b/akanda/neutron/plugins/decorators.py
@@ -254,7 +254,8 @@ def _update_internal_gateway_port_ip(context, router_id, subnet):
                 context,
                 routerport.router,
                 subnet['network_id'],
-                subnet
+                subnet['id'],
+                subnet['cidr']
             )
         except:
             LOG.info(


### PR DESCRIPTION
The decorator was silently failing because it was indirectly
calling the _check_for_dup_router_subnet which now need to
be called including the cidr of the subnet.

Signed-off-by: Rosario Di Somma <rosario.disomma@dreamhost.com>